### PR TITLE
Version 0.2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+# Extra linting for Markdown, Nix, TOML and YAML files
+name: Linting
+on:
+  push:
+    paths:
+      - "**/*.toml"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "**/*.nix"
+      - "**/*.md"
+  pull_request:
+    paths:
+      - "**/*.toml"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "**/*.nix"
+      - "**/*.md"
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+      - name: Check TOML formatting
+        run: nix run nixpkgs#taplo -- fmt --check
+      - name: Check YAML formatting
+        run: nix run nixpkgs#yamlfmt -- -lint
+      - name: Check Nix formatting
+        run: nix run nixpkgs#alejandra -- --check .
+      - name: Check Markdown formatting
+        run: nix run nixpkgs#mdformat -- --check .

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,7 @@ name: Python application
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  uv-build:
 
     runs-on: ubuntu-latest
 
@@ -42,3 +42,15 @@ jobs:
     - name: Test
       run: |
         python -m unittest discover tests
+
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Install Nix
+      uses: determinate-systems/nix-installer-action@v16
+
+    - name: Build with Nix
+      run: nix build

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,56 +1,40 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Python application
-
 on:
   push:
   pull_request:
-
 permissions:
   contents: read
-
 jobs:
   uv-build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.13"
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-
-    - name: Install dependencies
-      run: |
-        uv pip install --system . ruff
-
-    - name: Build with uv
-      run: |
-        uv build
-
-    - name: Lint and check formatting with Ruff
-      run: |
-        ruff check .
-        ruff format --check .
-
-    - name: Test
-      run: |
-        python -m unittest discover tests
-
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install dependencies
+        run: |
+          uv pip install --system . ruff
+      - name: Build with uv
+        run: |
+          uv build
+      - name: Lint and check formatting with Ruff
+        run: |
+          ruff check .
+          ruff format --check .
+      - name: Test
+        run: |
+          python -m unittest discover tests
   nix-build:
     runs-on: ubuntu-latest
     steps:
-
-    - uses: actions/checkout@v4
-
-    - name: Install Nix
-      uses: determinate-systems/nix-installer-action@v16
-
-    - name: Build with Nix
-      run: nix build
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+      - name: Build with Nix
+        run: nix build

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,6 +38,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    # - name: Test with pytest
-    #   run: |
-    #     pytest
+    - name: Test
+      run: |
+        python -m unittest discover tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,25 +17,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+
+    - name: Set up Python 3.13
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.13"
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
+
     - name: Install dependencies
       run: |
-        pip install flake8
-        
+        uv pip install --system . flake8
+
     - name: Build with uv
       run: |
         uv build
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test
       run: |
         python -m unittest discover tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,18 +28,16 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv pip install --system . flake8
+        uv pip install --system . ruff
 
     - name: Build with uv
       run: |
         uv build
 
-    - name: Lint with flake8
+    - name: Lint and check formatting with Ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff check .
+        ruff format --check .
 
     - name: Test
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,47 +1,36 @@
 # This workflow will upload a Python Package to PyPI when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-
 name: Upload Python Package
-
 on:
   push:
     branches:
       - main
     tags:
       - '**'
-
 permissions:
   contents: read
-
 jobs:
   release-build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-
       - name: Build release distributions
         run: |
           uv build
-
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:
           name: release-dists
           path: dist/
-
   pypi-publish:
     runs-on: ubuntu-latest
     needs:
@@ -49,20 +38,17 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-
     # Dedicated environments with protections for publishing are strongly recommended.
     # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
       url: https://pypi.org/project/lazyclone/${{ github.ref_name }}
-
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4
         with:
           name: release-dists
           path: dist/
-
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-01-10
+
+### Added
+
+- Support for other default hosts with `--host` argument.
+- Support for defaulting to clone with SSH with `--ssh` flag.
+- SSH shorthand starting with `@` (e.g., `@owner/repo`).
+- Support for flake-like repository references (e.g., `github:owner/repo`).
+- Documentation of development workflow in `CONTRIBUTING.md`.
+- Nix-based build job in CI.
+- Support for `taplo` (TOML), `alejandra` (Nix), `yamlfmt` (YAML), and `mdformat` (Markdown) formatters.
+- Unified `fmt` command in Nix development shell for project-wide formatting.
+- Dedicated GitHub Actions workflow for linting TOML, Nix, YAML, and Markdown.
+
+### Changed
+
+- Run checks on pushes and PRs to all branches.
+- Migrated Python linting and formatting from `flake8` to `ruff`.
+
+## [0.1.0] - 2026-01-08
+
+### Added
+
+- Initial release.
+- Support for lazy cloning from GitHub with search.
+- Support for opening cloned repository with program.
+- Nix flake installation.
+- Nix flake development environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thank you for your interest in contributing to lazyclone!
+
+All contributions are welcome, whether it be bug reports, feature requests, or pull requests.
+
+## How to Develop
+
+### Nix Flakes
+
+The recommended workflow is to use Nix Flakes to build the project and manage the environment.
+
+To enter a shell with all dependencies installed, run:
+
+```bash
+nix develop
+```
+
+> Note: If you don't have nix installed, you can install it from [here](https://nixos.org/download.html).
+
+If you wish to build without nix, you can use the `uv` commands described below.
+
+### Building
+
+With Nix flakes:
+
+```bash
+nix build
+```
+
+Without Nix flakes:
+
+```bash
+uv build
+```
+
+The resulting binary will be `./result/bin/lazyclone`.
+
+### Running tests
+
+```bash
+python -m unittest discover tests
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,31 @@ All contributions are welcome, whether it be bug reports, feature requests, or p
 
 The recommended workflow is to use Nix Flakes to build the project and manage the environment.
 
-To enter a shell with all dependencies installed, run:
+If you don't already have nix installed, you can install it from the [official downloads page](https://nixos.org/download.html).
+
+If you wish to build without nix, you can also use the `uv` commands described below.
+
+### Installing dependencies
+
+To enter a [Nix shell](https://nix.dev/manual/nix/stable/command-ref/nix-shell.html) with all dependencies installed, run:
 
 ```bash
 nix develop
 ```
 
-> Note: If you don't have nix installed, you can install it from [here](https://nixos.org/download.html).
+Without Nix flakes, create a virtual environment:
 
-If you wish to build without nix, you can use the `uv` commands described below.
+```bash
+uv venv
+```
+
+Then activate it with the command in the output.
+
+To install the dependencies globally, run:
+
+```bash
+uv pip install --system .
+```
 
 ### Building
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,11 @@ The resulting binary will be `./result/bin/lazyclone`.
 ```bash
 python -m unittest discover tests
 ```
+
+### Linting and Formatting
+
+To ensure a consistent code style, there are several formatters and linters installed as part of the Nix dev shell. You can run them all at once using the provided command (available in the Nix dev shell):
+
+```bash
+fmt
+```

--- a/README.md
+++ b/README.md
@@ -115,12 +115,15 @@ Install the package in your `configuration.nix` or an imported module:
 | `directory`      | string | Directory the repository should be cloned to | `lazyclone-2`       |
 | `-h`/`--help`    | flag   | Show the help menu                           |                     |
 | `-p`/`--program` | string | Program to open the cloned repository with   | `code`              |
+| `--host`         | string | URL for default git provider                 | `https://github.com`|
+| `--ssh`          | flag   | Prefer SSH over HTTPS                        |                     |
 | `--debug`        | flag   | Enable debug logs                            |                     |
 
 ### Help message
 
 ```console
-usage: lazyclone [-h] [-p PROGRAM] [--debug] repo [directory]
+usage: lazyclone [-h] [-p PROGRAM] [--host HOST] [--ssh] [--debug]
+                 repo [directory]
 
 Clone Git repositories easier
 
@@ -132,5 +135,7 @@ options:
   -h, --help            show this help message and exit
   -p, --program PROGRAM
                         open with this program after cloning
+  --host HOST           URL for default git host (default: https://github.com)
+  --ssh                 prefer ssh over https
   --debug               enable debugging output
 ```

--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ Install the package in your `configuration.nix` or an imported module:
 
 ### Arguments
 
-| Argument         | Type   | Description                                  | Example value       |
+| Argument | Type | Description | Example value |
 |------------------|--------|----------------------------------------------|---------------------|
-| `repo`           | string | Name or query of the repository to clone     | `olillin/lazyclone` |
-| `directory`      | string | Directory the repository should be cloned to | `lazyclone-2`       |
-| `-h`/`--help`    | flag   | Show the help menu                           |                     |
-| `-p`/`--program` | string | Program to open the cloned repository with   | `code`              |
-| `--host`         | string | URL for default git provider                 | `https://github.com`|
-| `--ssh`          | flag   | Prefer SSH over HTTPS                        |                     |
-| `--debug`        | flag   | Enable debug logs                            |                     |
+| `repo` | string | Name or query of the repository to clone | `olillin/lazyclone` |
+| `directory` | string | Directory the repository should be cloned to | `lazyclone-2` |
+| `-h`/`--help` | flag | Show the help menu | |
+| `-p`/`--program` | string | Program to open the cloned repository with | `code` |
+| `--host` | string | URL for default git provider | `https://github.com`|
+| `--ssh` | flag | Prefer SSH over HTTPS | |
+| `--debug` | flag | Enable debug logs | |
 
 ### Help message
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ $ lazyclone lazy
    aFarkas/lazysizes
 ```
 
+You can even tell lazyvim to immediately open your favorite editor after cloning:
+
+```console
+$ lazyclone bonk --program nvim
+Cloning https://github.com/olillin/bonk
+Successfully cloned into 'bonk'
+Launching nvim...
+```
+
 See [Usage](#usage) for more details.
 
 ## Installation

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767480499,
-        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767152253,
-        "narHash": "sha256-xxuRsew0pedwptVnhfru01xbe+dDhI+OY1kCFDMxBUs=",
+        "lastModified": 1767701098,
+        "narHash": "sha256-CJhKZnWb3gumR9oTRjFvCg/6lYTGbZRU7xtvcyWIRwU=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "7a3eb140416318349ec58d2d4e81afe071bc9f03",
+        "rev": "9d357f0d2ce6f5f35ec7959d7e704452352eb4da",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -62,14 +62,42 @@
         pkgs = nixpkgs.legacyPackages.${system};
         pythonSet = pythonSets.${system}.overrideScope editableOverlay;
         virtualenv = pythonSet.mkVirtualEnv "lazyclone-dev-env" workspace.deps.all;
+        fmt = pkgs.writeShellScriptBin "fmt" ''
+          set -e
+          echo "🎨 Running formatters and linters..."
+
+          echo "🐍 Running Ruff (Python)..."
+          ruff check . --fix
+          ruff format .
+
+          echo "📝 Running Taplo (TOML)..."
+          git ls-files --cached --others --exclude-standard '*.toml' | xargs -r taplo fmt
+
+          echo "❄️  Running Alejandra (Nix)..."
+          git ls-files --cached --others --exclude-standard '*.nix' | xargs -r alejandra
+
+          echo "📄 Running yamlfmt (YAML)..."
+          git ls-files --cached --others --exclude-standard '*.yaml' '*.yml' | xargs -r yamlfmt
+
+          echo "⬇️  Running mdformat (Markdown)..."
+          git ls-files --cached --others --exclude-standard '*.md' | xargs -r mdformat
+
+          echo "✅ All checks passed!"
+        '';
       in {
         default = pkgs.mkShell {
           packages =
-            [virtualenv]
+            [
+              virtualenv
+              fmt
+            ]
             ++ (with pkgs; [
               uv
               ruff
-              markdownlint-cli
+              taplo
+              alejandra
+              yamlfmt
+              mdformat
             ])
             ++ (with pkgs.python313Packages; [
               rich

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
               markdownlint-cli
             ])
             ++ (with pkgs.python313Packages; [
-              colorama
+              rich
               inquirer
             ]);
           env = {

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
           shellHook = ''
             unset PYTHONPATH
             export REPO_ROOT=$(git rev-parse --show-toplevel)
+            export NIXSHELL="$NIXSHELL+lazyclone"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,11 @@
               uv
               ruff
               markdownlint-cli
+            ])
+            ++ (with pkgs.python313Packages; [
+              colorama
+              inquirer
+              requests
             ]);
           env = {
             UV_NO_SYNC = "1";

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,6 @@
             ++ (with pkgs.python313Packages; [
               colorama
               inquirer
-              requests
             ]);
           env = {
             UV_NO_SYNC = "1";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,7 @@ authors = [{ name = 'Oli', email = 'oli@olillin.com' }]
 maintainers = [{ name = 'Oli', email = 'oli@olillin.com' }]
 
 requires-python = ">=3.13"
-dependencies = [
- "inquirer>=3.4.1",
- "rich>=14.2.0",
-]
+dependencies = ["inquirer>=3.4.1", "rich>=14.2.0"]
 
 [project.urls]
 "Bug Reports" = "https://github.com/olillin/lazyclone/issues"
@@ -23,4 +20,3 @@ lazyclone = 'lazyclone:main'
 [build-system]
 requires = ['uv_build>=0.9.0,<0.10.0']
 build-backend = 'uv_build'
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ maintainers = [{ name = 'Oli', email = 'oli@olillin.com' }]
 requires-python = ">=3.13"
 dependencies = [
  "inquirer>=3.4.1",
- "requests>=2.32.5",
  "rich>=14.2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ maintainers = [{ name = 'Oli', email = 'oli@olillin.com' }]
 requires-python = ">=3.13"
 dependencies = [
  "inquirer>=3.4.1",
+ "requests>=2.32.5",
  "rich>=14.2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lazyclone"
-version = "0.1.0"
+version = "0.2.0"
 description = "Git clone but easier"
 readme = "README.md"
 license = { file = 'LICENSE' }

--- a/src/lazyclone/__init__.py
+++ b/src/lazyclone/__init__.py
@@ -1,8 +1,8 @@
 import argparse
 import sys
-from .repository import *
-from .console import *
-from .program import *
+from .repository import lazy_clone
+from .console import console, debug, set_debug, errors
+from .program import run_program
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -56,13 +56,24 @@ def main():
     enable_debug = args.debug
     set_debug(enable_debug)
 
-    debug.log("Args:: Repo:", repo, "Output directory:", directory, "Program:", program, "Host:", host, "SSH: ", ssh)
+    debug.log(
+        "Args:: Repo:",
+        repo,
+        "Output directory:",
+        directory,
+        "Program:",
+        program,
+        "Host:",
+        host,
+        "SSH: ",
+        ssh,
+    )
 
     try:
         cloned_dir = lazy_clone(repo, directory, host, default_ssh=ssh)
 
-    except KeyboardInterrupt as e:
-        console.print(f"[red]Cancelled")
+    except KeyboardInterrupt:
+        console.print("[red]Cancelled")
         sys.exit(0)
     except Exception as e:
         errors.print(e)
@@ -84,4 +95,4 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        console.print(f"[red]Cancelled")
+        console.print("[red]Cancelled")

--- a/src/lazyclone/__init__.py
+++ b/src/lazyclone/__init__.py
@@ -26,8 +26,13 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--host",
-        help="default git provider to use (default: https://github.com)",
+        help="URL for default git host (default: https://github.com)",
         default="https://github.com",
+    )
+    parser.add_argument(
+        "--ssh",
+        action="store_true",
+        help="prefer ssh over https",
     )
     parser.add_argument(
         "--debug",
@@ -45,15 +50,16 @@ def main():
     directory = args.directory
     program = args.program
     host = args.host
+    ssh = args.ssh
 
     # Enable debugging
     enable_debug = args.debug
     set_debug(enable_debug)
 
-    debug.log("Args:: Repo:", repo, "Output directory:", directory, "Program:", program, "Host:", host)
+    debug.log("Args:: Repo:", repo, "Output directory:", directory, "Program:", program, "Host:", host, "SSH: ", ssh)
 
     try:
-        cloned_dir = lazy_clone(repo, directory, host)
+        cloned_dir = lazy_clone(repo, directory, host, default_ssh=ssh)
 
     except KeyboardInterrupt as e:
         console.print(f"[red]Cancelled")

--- a/src/lazyclone/__init__.py
+++ b/src/lazyclone/__init__.py
@@ -48,6 +48,9 @@ def main():
 
     try:
         cloned_dir = lazy_clone(repo, directory)
+    except KeyboardInterrupt as e:
+        console.print(f"[red]Cancelled")
+        sys.exit(0)
     except Exception as e:
         errors.print(e)
         sys.exit(1)
@@ -65,4 +68,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        console.print(f"[red]Cancelled")

--- a/src/lazyclone/__init__.py
+++ b/src/lazyclone/__init__.py
@@ -25,6 +25,11 @@ def parse_arguments() -> argparse.Namespace:
         help="open with this program after cloning",
     )
     parser.add_argument(
+        "--host",
+        help="default git provider to use (default: https://github.com)",
+        default="https://github.com",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="enable debugging output",
@@ -39,15 +44,17 @@ def main():
     repo = args.repo
     directory = args.directory
     program = args.program
+    host = args.host
 
     # Enable debugging
     enable_debug = args.debug
     set_debug(enable_debug)
 
-    debug.log("Args:: Repo:", repo, "Output directory:", directory, "Program:", program)
+    debug.log("Args:: Repo:", repo, "Output directory:", directory, "Program:", program, "Host:", host)
 
     try:
-        cloned_dir = lazy_clone(repo, directory)
+        cloned_dir = lazy_clone(repo, directory, host)
+
     except KeyboardInterrupt as e:
         console.print(f"[red]Cancelled")
         sys.exit(0)

--- a/src/lazyclone/console.py
+++ b/src/lazyclone/console.py
@@ -3,7 +3,10 @@ from rich.console import Console
 console = Console()
 
 debug = Console(style="blue")
+
+
 def set_debug(enabled: bool):
     debug.quiet = not enabled
+
 
 errors = Console(stderr=True, style="bold red")

--- a/src/lazyclone/git.py
+++ b/src/lazyclone/git.py
@@ -1,6 +1,6 @@
 import subprocess
 import platform
-from .console import *
+from .console import debug
 
 use_shell = platform.system() == "Windows"
 
@@ -29,9 +29,7 @@ def clone(url: str, output: str | None) -> str:
             raise Exception("Failed to clone git repository")
         else:
             message = process.stderr.decode()
-            raise Exception(
-                f"Failed to clone git repository: {process.stderr.decode()}"
-            )
+            raise Exception(f"Failed to clone git repository: {message}")
 
     output = process.stderr.decode()
     return _find_clone_output(output)

--- a/src/lazyclone/github.py
+++ b/src/lazyclone/github.py
@@ -1,0 +1,106 @@
+import subprocess
+import math
+import platform
+from .console import *
+
+use_shell = platform.system() == "Windows"
+
+
+def github_username() -> str | None:
+    """Get the GitHub username of the logged in user using the `gh` CLI. Returns None if it failed"""
+    process = subprocess.run(
+        ["gh", "api", "https://api.github.com/user", "--jq", ".login"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=use_shell,
+    )
+
+    if process.returncode != 0 or process.stdout is None:
+        # Unable to get username
+        debug.log(f"Failed to get GitHub username")
+        if process.stderr:
+            debug.log(process.stderr.decode())
+        return None
+    return process.stdout.decode().strip()
+
+
+def search_repository_names(query: str, owner: str | None, limit: int) -> list[str]:
+    """Search the GitHub API for repositories matching a query"""
+    debug.log(f"Searching for repositories with query '{query}' and owner {owner}")
+
+    owner_string = f" owner:{owner}" if owner is not None else ""
+    process = subprocess.run(
+        [
+            "gh",
+            "api",
+            "search/repositories",
+            "--method",
+            "GET",
+            "-f",
+            f"q={query}{owner_string} fork:true",
+            "-f",
+            "per_page={limit}",
+            "-q",
+            ".items[]|.full_name",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=use_shell,
+    )
+
+    def get_names(stdout: str) -> list[str]:
+        return [line.strip() for line in stdout.split("\n") if line.strip() != ""]
+
+    if process.returncode != 0 or process.stdout is None:
+        summary = f"Failed to search for GitHub repositories with query: '{query}' and owner '{owner}'"
+        if process.stderr is None:
+            raise Exception(summary)
+        else:
+            raise Exception(summary + ": " + process.stdout.decode())
+
+    names = get_names(process.stdout.decode())[:limit]
+    debug.log(f"Found repositories: {names}")
+    return names
+
+
+def github_repositories(query: str, owner: str | None, limit: int = 6) -> list[str]:
+    repositories: list[str] = []
+
+    if owner is not None:
+        # Get repositories owned by the specified owner
+        search_limit = math.ceil(limit / 2)
+        debug.log(f"Searching for {search_limit} user repositories")
+        names = search_repository_names(query, owner, search_limit)
+        repositories.extend(names)
+
+    # Get repositories from all of GitHub
+    remaining_limit = limit - len(repositories)
+    if remaining_limit <= 0:
+        return repositories
+
+    debug.log(f"Searching for {remaining_limit} remaining repositories")
+    names = search_repository_names(query, None, remaining_limit)
+    for name in names:
+        if name not in repositories:
+            repositories.append(name)
+
+    return repositories
+
+
+def github_repository_exists(owner: str, repo: str) -> bool:
+    debug.log(f"Checking if {owner}/{repo} exists on GitHub")
+    process = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{owner}/{repo}",
+            "--method",
+            "GET",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=use_shell,
+    )
+    exists = process.returncode == 0
+    debug.log(f"Exists on GitHub ({owner}/{repo}): {exists}")
+    return exists

--- a/src/lazyclone/github.py
+++ b/src/lazyclone/github.py
@@ -1,7 +1,7 @@
 import subprocess
 import math
 import platform
-from .console import *
+from .console import debug
 
 use_shell = platform.system() == "Windows"
 
@@ -17,7 +17,7 @@ def github_username() -> str | None:
 
     if process.returncode != 0 or process.stdout is None:
         # Unable to get username
-        debug.log(f"Failed to get GitHub username")
+        debug.log("Failed to get GitHub username")
         if process.stderr:
             debug.log(process.stderr.decode())
         return None

--- a/src/lazyclone/program.py
+++ b/src/lazyclone/program.py
@@ -1,5 +1,5 @@
 import os
-from .console import *
+from .console import debug
 
 
 def run_program(program: str, cloned_dir: str) -> str | None:

--- a/src/lazyclone/repository.py
+++ b/src/lazyclone/repository.py
@@ -38,6 +38,12 @@ def resolve_repo(repo: str) -> str:
         if username is not None:
             repo = username + "/" + repo
 
+    # Assume https:// if it is a URL with no protocol specified
+    if "/" in repo and "." in repo.split("/")[0]:
+        url = "https://" + repo
+        if check_repository_exists(url):
+            return url
+
     # Resolve repository owner and name
     if re.match("^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$", repo):
         url = "https://github.com/" + repo
@@ -45,11 +51,9 @@ def resolve_repo(repo: str) -> str:
             return url
 
     # Use GitHub search as fallback
-    divider: int = repo.find("/")
     owner: str | None
-    if divider > -1:
-        owner = repo[:divider]
-        repo = repo[divider + 1 :]
+    if "/" in repo:
+        owner, repo = repo.split("/", maxsplit=1)
     else:
         owner = None
 

--- a/src/lazyclone/repository.py
+++ b/src/lazyclone/repository.py
@@ -43,7 +43,9 @@ def build_url(path: str, host: str, ssh: bool = False) -> str:
         domain = host.split("://")[-1].rstrip("/")
         return f"git@{domain}:{path}"
     else:
-        return host + path
+        # If host already ends with a separator, don't add another one
+        separator = "" if host[-1] in ["/", "~"] else "/"
+        return host + separator + path.lstrip("/")
 
 def resolve_repo(repo: str, host: str = "https://github.com", default_ssh: bool = False) -> str:
     if "://" not in host:
@@ -52,7 +54,7 @@ def resolve_repo(repo: str, host: str = "https://github.com", default_ssh: bool 
     repo = repo.strip()
 
     # Don't resolve already completed URLs
-    if "://" in repo or "@" in repo and not repo.startswith("git@"):
+    if "://" in repo or (":" in repo and "@" in repo and not repo.startswith("@") and not repo.startswith("git@")):
         if repo.startswith(FLAKE_GIT_PREFIX):
             return repo[len(FLAKE_GIT_PREFIX):]
         return repo

--- a/src/lazyclone/repository.py
+++ b/src/lazyclone/repository.py
@@ -35,7 +35,7 @@ def find_repo_choices(repo: str, owner: str | None = None) -> list[str]:
     return github_repositories(repo, owner)
 
 
-def resolve_repo(repo: str) -> str:
+def resolve_repo(repo: str, host: str = "https://github.com") -> str:
     # Don't resolve already completed URLs
     if "://" in repo or "@" in repo:
         if repo.startswith(FLAKE_GIT_PREFIX):
@@ -50,9 +50,9 @@ def resolve_repo(repo: str) -> str:
 
     # Resolve Nix Flake-like URLs
     if ":" in repo:
-        for key, host in FLAKE_PREFIXES.items():
+        for key, prefix in FLAKE_PREFIXES.items():
             if repo.startswith(key + ":"):
-                url = host + repo[len(key) + 1 :]
+                url = prefix + repo[len(key) + 1 :]
                 if check_repository_exists(url):
                     return url
 
@@ -64,7 +64,8 @@ def resolve_repo(repo: str) -> str:
 
     # Resolve repository owner and name
     if re.match("^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$", repo):
-        url = "https://github.com/" + repo
+        base = host.rstrip("/") + "/"
+        url = base + repo
         if check_repository_exists(url):
             return url
 
@@ -88,8 +89,8 @@ def get_repo_name(url: str) -> str:
     return match.group(0)
 
 
-def lazy_clone(repo: str, directory: str | None) -> str:
-    url = resolve_repo(repo)
+def lazy_clone(repo: str, directory: str | None, host: str = "https://github.com") -> str:
+    url = resolve_repo(repo, host)
     debug.log(f"Resolved URL to {url}")
     console.print(f"Cloning [yellow]{url}")
     output = git_clone(url, directory)

--- a/tests/test_integration_clone.py
+++ b/tests/test_integration_clone.py
@@ -1,0 +1,75 @@
+
+import unittest
+import sys
+import os
+import tempfile
+import subprocess
+import shutil
+
+# Ensure src is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from lazyclone.git import clone
+
+class TestIntegrationClone(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory for the source repo
+        self.source_dir = tempfile.mkdtemp(prefix="lazyclone_src_")
+        self.dest_parent_dir = tempfile.mkdtemp(prefix="lazyclone_dest_")
+        
+        # Initialize a git repo in source_dir
+        subprocess.run(["git", "init"], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "config", "user.email", "you@example.com"], cwd=self.source_dir, check=True)
+        subprocess.run(["git", "config", "user.name", "Your Name"], cwd=self.source_dir, check=True)
+        subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=self.source_dir, check=True)
+        
+        # Create a dummy file and commit it
+        with open(os.path.join(self.source_dir, "test.txt"), "w") as f:
+            f.write("hello world")
+        subprocess.run(["git", "add", "."], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL)
+
+    def tearDown(self):
+        shutil.rmtree(self.source_dir)
+        shutil.rmtree(self.dest_parent_dir)
+
+    def test_clone_local_repo(self):
+        # Clone the local repo to a new folder in dest_parent_dir
+        # We pass the local path as the URL
+        
+        # Expected output directory name (default is the folder name of source)
+        expected_name = os.path.basename(self.source_dir)
+        
+        # Perform clone
+        clone(self.source_dir, os.path.join(self.dest_parent_dir, "cloned_repo"))
+        
+        # Verify it cloned
+        cloned_path = os.path.join(self.dest_parent_dir, "cloned_repo")
+        self.assertTrue(os.path.exists(cloned_path))
+        self.assertTrue(os.path.exists(os.path.join(cloned_path, ".git")))
+        self.assertTrue(os.path.exists(os.path.join(cloned_path, "test.txt")))
+        
+        # Verify git log
+        result = subprocess.run(["git", "log", "--oneline"], cwd=cloned_path, capture_output=True, text=True)
+        self.assertIn("Initial commit", result.stdout)
+
+    def test_clone_with_custom_name(self):
+        # Test cloning into a specific directory name
+        custom_name = "my_custom_repo"
+        target_path = os.path.join(self.dest_parent_dir, custom_name)
+        
+        # Perform clone
+        cloned_name = clone(self.source_dir, target_path)
+        
+        # Verify return value (git.py logic extracts the path)
+        # Note: git.py extraction might return the full path if provided, or relative.
+        # Git usually echoes what you typed.
+        self.assertIn(custom_name, cloned_name)
+        
+        # Verify existence
+        self.assertTrue(os.path.exists(target_path))
+        self.assertTrue(os.path.exists(os.path.join(target_path, "test.txt")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integration_clone.py
+++ b/tests/test_integration_clone.py
@@ -1,4 +1,3 @@
-
 import unittest
 import sys
 import os
@@ -11,23 +10,46 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 
 from lazyclone.git import clone
 
+
 class TestIntegrationClone(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory for the source repo
         self.source_dir = tempfile.mkdtemp(prefix="lazyclone_src_")
         self.dest_parent_dir = tempfile.mkdtemp(prefix="lazyclone_dest_")
-        
+
         # Initialize a git repo in source_dir
-        subprocess.run(["git", "init"], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL)
-        subprocess.run(["git", "config", "user.email", "you@example.com"], cwd=self.source_dir, check=True)
-        subprocess.run(["git", "config", "user.name", "Your Name"], cwd=self.source_dir, check=True)
-        subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=self.source_dir, check=True)
-        
+        subprocess.run(
+            ["git", "init"], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "you@example.com"],
+            cwd=self.source_dir,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Your Name"], cwd=self.source_dir, check=True
+        )
+        subprocess.run(
+            ["git", "config", "commit.gpgsign", "false"],
+            cwd=self.source_dir,
+            check=True,
+        )
+
         # Create a dummy file and commit it
         with open(os.path.join(self.source_dir, "test.txt"), "w") as f:
             f.write("hello world")
-        subprocess.run(["git", "add", "."], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL)
-        subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=self.source_dir, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=self.source_dir,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=self.source_dir,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
 
     def tearDown(self):
         shutil.rmtree(self.source_dir)
@@ -36,36 +58,35 @@ class TestIntegrationClone(unittest.TestCase):
     def test_clone_local_repo(self):
         # Clone the local repo to a new folder in dest_parent_dir
         # We pass the local path as the URL
-        
-        # Expected output directory name (default is the folder name of source)
-        expected_name = os.path.basename(self.source_dir)
-        
+
         # Perform clone
         clone(self.source_dir, os.path.join(self.dest_parent_dir, "cloned_repo"))
-        
+
         # Verify it cloned
         cloned_path = os.path.join(self.dest_parent_dir, "cloned_repo")
         self.assertTrue(os.path.exists(cloned_path))
         self.assertTrue(os.path.exists(os.path.join(cloned_path, ".git")))
         self.assertTrue(os.path.exists(os.path.join(cloned_path, "test.txt")))
-        
+
         # Verify git log
-        result = subprocess.run(["git", "log", "--oneline"], cwd=cloned_path, capture_output=True, text=True)
+        result = subprocess.run(
+            ["git", "log", "--oneline"], cwd=cloned_path, capture_output=True, text=True
+        )
         self.assertIn("Initial commit", result.stdout)
 
     def test_clone_with_custom_name(self):
         # Test cloning into a specific directory name
         custom_name = "my_custom_repo"
         target_path = os.path.join(self.dest_parent_dir, custom_name)
-        
+
         # Perform clone
         cloned_name = clone(self.source_dir, target_path)
-        
+
         # Verify return value (git.py logic extracts the path)
         # Note: git.py extraction might return the full path if provided, or relative.
         # Git usually echoes what you typed.
         self.assertIn(custom_name, cloned_name)
-        
+
         # Verify existence
         self.assertTrue(os.path.exists(target_path))
         self.assertTrue(os.path.exists(os.path.join(target_path, "test.txt")))

--- a/tests/test_repository_resolution.py
+++ b/tests/test_repository_resolution.py
@@ -44,5 +44,12 @@ class TestRepositoryResolution(unittest.TestCase):
          result = resolve_repo("sourcehut:emersion/mrsh")
          self.assertEqual(result, "https://git.sr.ht/~emersion/mrsh")
 
+    def test_custom_host(self):
+        # input: "gitlab-org/gitlab-foss", host="https://gitlab.com"
+        # Since we use check_repository_exists, we need a real repo.
+        result = resolve_repo("gitlab-org/gitlab-foss", host="https://gitlab.com")
+        self.assertEqual(result, "https://gitlab.com/gitlab-org/gitlab-foss")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_resolution.py
+++ b/tests/test_repository_resolution.py
@@ -50,6 +50,40 @@ class TestRepositoryResolution(unittest.TestCase):
         result = resolve_repo("gitlab-org/gitlab-foss", host="https://gitlab.com")
         self.assertEqual(result, "https://gitlab.com/gitlab-org/gitlab-foss")
 
+    def test_ssh_shorthand(self):
+        # input: "@olillin/lazyclone"
+        # Should resolve to git@github.com:olillin/lazyclone
+        result = resolve_repo("@olillin/lazyclone")
+        self.assertEqual(result, "git@github.com:olillin/lazyclone")
+
+    def test_custom_host_ssh_shorthand(self):
+        # input: "@olillin/lazyclone" with host "https://gitlab.com"
+        result = resolve_repo("@olillin/lazyclone", host="https://gitlab.com")
+        self.assertEqual(result, "git@gitlab.com:olillin/lazyclone")
+
+    def test_git_prefixed_ssh_shorthand(self):
+        # input: "git@olillin/lazyclone"
+        result = resolve_repo("git@olillin/lazyclone")
+        self.assertEqual(result, "git@github.com:olillin/lazyclone")
+
+    def test_ssh_shorthand_flake_syntax(self):
+        # input: "@gitlab:olillin/lazyclone"
+        # Should resolve to git@gitlab.com:olillin/lazyclone
+        result = resolve_repo("@gitlab:olillin/lazyclone")
+        self.assertEqual(result, "git@gitlab.com:olillin/lazyclone")
+
+    def test_complete_ssh_url(self):
+        # input: "olillin@git.olillin.com:foo/bar"
+        result = resolve_repo("olillin@git.olillin.com:foo/bar")
+        self.assertEqual(result, "olillin@git.olillin.com:foo/bar")
+
+    def test_complete_ssh_url_with_port(self):
+        # input: "olillin@git.olillin.com:2222:foo/bar"
+        result = resolve_repo("olillin@git.olillin.com:2222:foo/bar")
+        self.assertEqual(result, "olillin@git.olillin.com:2222:foo/bar")
+
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_resolution.py
+++ b/tests/test_repository_resolution.py
@@ -1,5 +1,6 @@
 
 import unittest
+from unittest.mock import patch, MagicMock
 import sys
 import os
 
@@ -9,80 +10,102 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 from lazyclone.repository import resolve_repo
 
 class TestRepositoryResolution(unittest.TestCase):
-    def test_github_implicit(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_github_implicit(self, mock_check):
         # input: "olillin/olillin"
         # Since this resolves via network check or github searching, we expect it to resolve to the full URL.
-        # Note: resolve_repo might depend on check_repository_exists which does a real network call.
+        mock_check.return_value = True
         result = resolve_repo("olillin/olillin")
         self.assertEqual(result, "https://github.com/olillin/olillin")
+        mock_check.assert_called_with("https://github.com/olillin/olillin")
 
-    def test_github_flake_style(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_github_flake_style(self, mock_check):
+        mock_check.return_value = True
         # input: "github:olillin/olillin"
         result = resolve_repo("github:olillin/olillin")
         self.assertEqual(result, "https://github.com/olillin/olillin")
 
-    def test_direct_url(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_direct_url(self, mock_check):
+        mock_check.return_value = True
         # input: "https://github.com/olillin/olillin"
         url = "https://github.com/olillin/olillin"
         result = resolve_repo(url)
         self.assertEqual(result, url)
 
-    def test_git_plus_prefix(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_git_plus_prefix(self, mock_check):
+        mock_check.return_value = True
         # input: "git+https://github.com/olillin/olillin"
         # Should strip "git+" and return "https://..."
         result = resolve_repo("git+https://github.com/olillin/olillin")
         self.assertEqual(result, "https://github.com/olillin/olillin")
     
-    def test_gitlab_flake(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_gitlab_flake(self, mock_check):
+        mock_check.return_value = True
         # input: "gitlab:gitlab-org/gitlab-foss"
-        # Assuming this repo exists and check_repository_exists returns True
         result = resolve_repo("gitlab:gitlab-org/gitlab-foss")
         self.assertEqual(result, "https://gitlab.com/gitlab-org/gitlab-foss")
 
-    def test_sourcehut_flake(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_sourcehut_flake(self, mock_check):
+         mock_check.return_value = True
          # input: "sourcehut:emersion/mrsh"
          result = resolve_repo("sourcehut:emersion/mrsh")
          self.assertEqual(result, "https://git.sr.ht/~emersion/mrsh")
 
-    def test_custom_host(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_custom_host(self, mock_check):
+        mock_check.return_value = True
         # input: "gitlab-org/gitlab-foss", host="https://gitlab.com"
-        # Since we use check_repository_exists, we need a real repo.
         result = resolve_repo("gitlab-org/gitlab-foss", host="https://gitlab.com")
         self.assertEqual(result, "https://gitlab.com/gitlab-org/gitlab-foss")
 
-    def test_ssh_shorthand(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_ssh_shorthand(self, mock_check):
+        mock_check.return_value = True
         # input: "@olillin/lazyclone"
         # Should resolve to git@github.com:olillin/lazyclone
         result = resolve_repo("@olillin/lazyclone")
         self.assertEqual(result, "git@github.com:olillin/lazyclone")
 
-    def test_custom_host_ssh_shorthand(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_custom_host_ssh_shorthand(self, mock_check):
+        mock_check.return_value = True
         # input: "@olillin/lazyclone" with host "https://gitlab.com"
         result = resolve_repo("@olillin/lazyclone", host="https://gitlab.com")
         self.assertEqual(result, "git@gitlab.com:olillin/lazyclone")
 
-    def test_git_prefixed_ssh_shorthand(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_git_prefixed_ssh_shorthand(self, mock_check):
+        mock_check.return_value = True
         # input: "git@olillin/lazyclone"
         result = resolve_repo("git@olillin/lazyclone")
         self.assertEqual(result, "git@github.com:olillin/lazyclone")
 
-    def test_ssh_shorthand_flake_syntax(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_ssh_shorthand_flake_syntax(self, mock_check):
+        mock_check.return_value = True
         # input: "@gitlab:olillin/lazyclone"
         # Should resolve to git@gitlab.com:olillin/lazyclone
         result = resolve_repo("@gitlab:olillin/lazyclone")
         self.assertEqual(result, "git@gitlab.com:olillin/lazyclone")
 
-    def test_complete_ssh_url(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_complete_ssh_url(self, mock_check):
+        mock_check.return_value = True
         # input: "olillin@git.olillin.com:foo/bar"
         result = resolve_repo("olillin@git.olillin.com:foo/bar")
         self.assertEqual(result, "olillin@git.olillin.com:foo/bar")
 
-    def test_complete_ssh_url_with_port(self):
+    @patch("lazyclone.repository.check_repository_exists")
+    def test_complete_ssh_url_with_port(self, mock_check):
+        mock_check.return_value = True
         # input: "olillin@git.olillin.com:2222:foo/bar"
         result = resolve_repo("olillin@git.olillin.com:2222:foo/bar")
         self.assertEqual(result, "olillin@git.olillin.com:2222:foo/bar")
-
-
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_resolution.py
+++ b/tests/test_repository_resolution.py
@@ -1,0 +1,48 @@
+
+import unittest
+import sys
+import os
+
+# Ensure src is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from lazyclone.repository import resolve_repo
+
+class TestRepositoryResolution(unittest.TestCase):
+    def test_github_implicit(self):
+        # input: "olillin/olillin"
+        # Since this resolves via network check or github searching, we expect it to resolve to the full URL.
+        # Note: resolve_repo might depend on check_repository_exists which does a real network call.
+        result = resolve_repo("olillin/olillin")
+        self.assertEqual(result, "https://github.com/olillin/olillin")
+
+    def test_github_flake_style(self):
+        # input: "github:olillin/olillin"
+        result = resolve_repo("github:olillin/olillin")
+        self.assertEqual(result, "https://github.com/olillin/olillin")
+
+    def test_direct_url(self):
+        # input: "https://github.com/olillin/olillin"
+        url = "https://github.com/olillin/olillin"
+        result = resolve_repo(url)
+        self.assertEqual(result, url)
+
+    def test_git_plus_prefix(self):
+        # input: "git+https://github.com/olillin/olillin"
+        # Should strip "git+" and return "https://..."
+        result = resolve_repo("git+https://github.com/olillin/olillin")
+        self.assertEqual(result, "https://github.com/olillin/olillin")
+    
+    def test_gitlab_flake(self):
+        # input: "gitlab:gitlab-org/gitlab-foss"
+        # Assuming this repo exists and check_repository_exists returns True
+        result = resolve_repo("gitlab:gitlab-org/gitlab-foss")
+        self.assertEqual(result, "https://gitlab.com/gitlab-org/gitlab-foss")
+
+    def test_sourcehut_flake(self):
+         # input: "sourcehut:emersion/mrsh"
+         result = resolve_repo("sourcehut:emersion/mrsh")
+         self.assertEqual(result, "https://git.sr.ht/~emersion/mrsh")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,56 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
 name = "editor"
 version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
@@ -35,6 +85,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/92/734a4ab345914259cb6146fd36512608ea42be16195375c379046f33283d/editor-1.6.6.tar.gz", hash = "sha256:bb6989e872638cd119db9a4fce284cd8e13c553886a1c044c6b8d8a160c871f8", size = 3197, upload-time = "2024-01-25T10:44:59.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/c2/4bc8cd09b14e28ce3f406a8b05761bed0d785d1ca8c2a5c6684d884c66a2/editor-1.6.6-py3-none-any.whl", hash = "sha256:e818e6913f26c2a81eadef503a2741d7cca7f235d20e217274a009ecd5a74abf", size = 4017, upload-time = "2024-01-25T10:44:58.66Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -69,12 +128,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "inquirer" },
+    { name = "requests" },
     { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "inquirer", specifier = ">=3.4.1" },
+    { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
 
@@ -118,6 +179,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -140,6 +216,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/6d/b9aace390f62db5d7d2c77eafce3d42774f27f1829d24fa9b6f598b3ef71/runs-1.2.2.tar.gz", hash = "sha256:9dc1815e2895cfb3a48317b173b9f1eac9ba5549b36a847b5cc60c3bf82ecef1", size = 5474, upload-time = "2024-01-25T14:44:01.563Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/d6/17caf2e4af1dec288477a0cbbe4a96fbc9b8a28457dce3f1f452630ce216/runs-1.2.2-py3-none-any.whl", hash = "sha256:0980dcbc25aba1505f307ac4f0e9e92cbd0be2a15a1e983ee86c24c87b839dfd", size = 7033, upload-time = "2024-01-25T14:43:59.959Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -25,56 +25,6 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2026.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
 name = "editor"
 version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
@@ -85,15 +35,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/92/734a4ab345914259cb6146fd36512608ea42be16195375c379046f33283d/editor-1.6.6.tar.gz", hash = "sha256:bb6989e872638cd119db9a4fce284cd8e13c553886a1c044c6b8d8a160c871f8", size = 3197, upload-time = "2024-01-25T10:44:59.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/c2/4bc8cd09b14e28ce3f406a8b05761bed0d785d1ca8c2a5c6684d884c66a2/editor-1.6.6-py3-none-any.whl", hash = "sha256:e818e6913f26c2a81eadef503a2741d7cca7f235d20e217274a009ecd5a74abf", size = 4017, upload-time = "2024-01-25T10:44:58.66Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -128,14 +69,12 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "inquirer" },
-    { name = "requests" },
     { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "inquirer", specifier = ">=3.4.1" },
-    { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
 
@@ -179,21 +118,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -216,15 +140,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/6d/b9aace390f62db5d7d2c77eafce3d42774f27f1829d24fa9b6f598b3ef71/runs-1.2.2.tar.gz", hash = "sha256:9dc1815e2895cfb3a48317b173b9f1eac9ba5549b36a847b5cc60c3bf82ecef1", size = 5474, upload-time = "2024-01-25T14:44:01.563Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/d6/17caf2e4af1dec288477a0cbbe4a96fbc9b8a28457dce3f1f452630ce216/runs-1.2.2-py3-none-any.whl", hash = "sha256:0980dcbc25aba1505f307ac4f0e9e92cbd0be2a15a1e983ee86c24c87b839dfd", size = 7033, upload-time = "2024-01-25T14:43:59.959Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

### Added

- Support for other default hosts with `--host` argument.
- Support for defaulting to clone with SSH with `--ssh` flag.
- SSH shorthand starting with `@` (e.g., `@owner/repo`).
- Support for flake-like repository references (e.g., `github:owner/repo`).
- Documentation of development workflow in `CONTRIBUTING.md`.
- Nix-based build job in CI.
- Support for `taplo` (TOML), `alejandra` (Nix), `yamlfmt` (YAML), and `mdformat` (Markdown) formatters.
- Unified `fmt` command in Nix development shell for project-wide formatting.
- Dedicated GitHub Actions workflow for linting TOML, Nix, YAML, and Markdown.

### Changed

- Run checks on pushes and PRs to all branches.
- Migrated Python linting and formatting from `flake8` to `ruff`.